### PR TITLE
Add sample deprecation status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Creating an application with a .NET60 code sample
 
+> [!WARNING]
+> This devfile sample has been deprecated and will no longer be maintained. It has been archived and will remain read-only.
+
 **Note:** The .NET60 code sample uses the **8081** HTTP port.
 
 Before you begin creating an application with this `devfile` code sample, it's helpful to understand the relationship between the `devfile` and `Dockerfile` and how they contribute to your build. You can find these files at the following URLs:


### PR DESCRIPTION
# Description

Since this sample has been deprecated in the community devfile registry since https://github.com/devfile/registry/commit/a7d6477e7de10e9f9c761f63139ece3798f69ad3, we should reflect that deprecation status here and archive this repository.